### PR TITLE
step line numbers are recorded when protocol is loaded (#65) (#121)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,7 +274,7 @@ dependencies = [
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-utils 0.1.0",
  "trim-margin 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.3 (git+https://github.com/hallettj/yaml-rust?rev=5216abe1f7d24ccd17a3b1b1e56c0114758d5ed7)",
 ]
 
 [[package]]
@@ -396,9 +406,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.4.3"
+source = "git+https://github.com/hallettj/yaml-rust?rev=5216abe1f7d24ccd17a3b1b1e56c0114758d5ed7#5216abe1f7d24ccd17a3b1b1e56c0114758d5ed7"
 dependencies = [
+ "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -414,6 +425,7 @@ dependencies = [
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum ctor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9a43db2bba5cafdc6aa068c892a518e477ee0df3705e53ec70247a9ff93546d5"
+"checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
@@ -454,4 +466,4 @@ dependencies = [
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95acf0db5515d07da9965ec0e0ba6cc2d825e2caeb7303b66ca441729801254e"
+"checksum yaml-rust 0.4.3 (git+https://github.com/hallettj/yaml-rust?rev=5216abe1f7d24ccd17a3b1b1e56c0114758d5ed7)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 nix = "*"
 libc = "*"
 tempdir = "*"
-yaml-rust = "*"
+yaml-rust = { git = "https://github.com/hallettj/yaml-rust", rev = "5216abe1f7d24ccd17a3b1b1e56c0114758d5ed7" }
 linked-hash-map = "*"
 bincode = "*"
 quale = "*"

--- a/src/protocol/marker.rs
+++ b/src/protocol/marker.rs
@@ -1,0 +1,32 @@
+use yaml_rust;
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
+pub struct Marker {
+    pub line: usize,
+    pub col: usize,
+}
+
+impl Marker {
+    pub fn line(&self) -> usize {
+        let Marker { line, .. } = self;
+        *line
+    }
+}
+
+impl<'a> From<&'a yaml_rust::Marker> for Marker {
+    fn from(marker: &'a yaml_rust::Marker) -> Self {
+        Marker {
+            line: marker.line(),
+            col: marker.col(),
+        }
+    }
+}
+
+impl From<yaml_rust::Marker> for Marker {
+    fn from(marker: yaml_rust::Marker) -> Self {
+        Marker {
+            line: marker.line(),
+            col: marker.col(),
+        }
+    }
+}

--- a/src/protocol/yaml.rs
+++ b/src/protocol/yaml.rs
@@ -3,32 +3,40 @@ use linked_hash_map::LinkedHashMap;
 use std::fmt;
 use std::io;
 use std::io::Cursor;
-use yaml_rust::{yaml::Hash, Yaml, YamlEmitter};
+use yaml_rust::{yaml::HashNode, Node, Yaml, YamlEmitter, YamlMarked, YamlNode};
 
 pub trait YamlExt {
+    type Child;
+
     fn expect_str(&self) -> R<&str>;
 
-    fn expect_array(&self) -> R<&Vec<Yaml>>;
+    fn expect_array(&self) -> R<&Vec<Self::Child>>;
 
-    fn expect_object(&self) -> R<&LinkedHashMap<Yaml, Yaml>>;
+    fn expect_object(&self) -> R<&LinkedHashMap<Self::Child, Self::Child>>;
 
     fn expect_integer(&self) -> R<i32>;
 }
 
-impl YamlExt for Yaml {
+impl<T> YamlExt for T
+where
+    T: fmt::Debug + YamlNode,
+    <T as YamlNode>::Child: fmt::Debug,
+{
+    type Child = <T as YamlNode>::Child;
+
     fn expect_str(&self) -> R<&str> {
         Ok(self
             .as_str()
             .ok_or_else(|| format!("expected: string, got: {:?}", self))?)
     }
 
-    fn expect_array(&self) -> R<&Vec<Yaml>> {
+    fn expect_array(&self) -> R<&Vec<Self::Child>> {
         Ok(self
             .as_vec()
             .ok_or_else(|| format!("expected: array, got: {:?}", self))?)
     }
 
-    fn expect_object(&self) -> R<&LinkedHashMap<Yaml, Yaml>> {
+    fn expect_object(&self) -> R<&LinkedHashMap<Self::Child, Self::Child>> {
         Ok(self
             .as_hash()
             .ok_or_else(|| format!("expected: object, got: {:?}", self))?)
@@ -75,18 +83,18 @@ mod yaml_ext {
 }
 
 pub trait MapExt {
-    fn expect_field(&self, field: &str) -> R<&Yaml>;
+    fn expect_field(&self, field: &str) -> R<&Node>;
 }
 
-impl MapExt for LinkedHashMap<Yaml, Yaml> {
-    fn expect_field(&self, field: &str) -> R<&Yaml> {
+impl MapExt for LinkedHashMap<Node, Node> {
+    fn expect_field(&self, field: &str) -> R<&Node> {
         Ok(self
-            .get(&Yaml::String(field.to_string()))
+            .get(&Node(YamlMarked::String(field.to_string()), None))
             .ok_or_else(|| format!("expected field '{}', got: {:?}", field, self))?)
     }
 }
 
-pub fn check_keys(known_keys: &[&str], object: &Hash) -> R<()> {
+pub fn check_keys(known_keys: &[&str], object: &HashNode) -> R<()> {
     for key in object.keys() {
         let key = key.expect_str()?;
         if !known_keys.contains(&key) {

--- a/src/protocol_checker/mod.rs
+++ b/src/protocol_checker/mod.rs
@@ -52,6 +52,7 @@ impl ProtocolChecker {
             Some(next_protocol_step) => {
                 if !next_protocol_step.command_matcher.matches(&received) {
                     self.register_step_error(
+                        next_protocol_step.marker(),
                         &next_protocol_step.command_matcher.format(),
                         &received.format(),
                     );
@@ -62,7 +63,7 @@ impl ProtocolChecker {
                 }
             }
             None => {
-                self.register_step_error("<protocol end>", &received.format());
+                self.register_step_error(None, "<protocol end>", &received.format());
                 ProtocolChecker::allow_failing_scripts_to_continue()
             }
         };
@@ -74,10 +75,19 @@ impl ProtocolChecker {
         Ok(path)
     }
 
-    fn register_step_error(&mut self, expected: &str, received: &str) {
+    fn register_step_error(
+        &mut self,
+        marker: Option<protocol::Marker>,
+        expected: &str,
+        received: &str,
+    ) {
+        let location = match marker {
+            Some(marker) => format!("  in step on line {},\n", marker.line()),
+            _ => "".to_string(),
+        };
         self.register_error(format!(
-            "  expected: {}\n  received: {}\n",
-            expected, received
+            "{}  expected: {}\n  received: {}\n",
+            location, expected, received
         ));
     }
 
@@ -156,6 +166,7 @@ impl SyscallMock for ProtocolChecker {
     fn handle_end(mut self, exitcode: i32, redirector: &Redirector) -> R<CheckerResult> {
         if let Some(expected_step) = self.protocol.steps.pop_front() {
             self.register_step_error(
+                expected_step.marker(),
                 &expected_step.command_matcher.format(),
                 "<script terminated>",
             );
@@ -163,6 +174,7 @@ impl SyscallMock for ProtocolChecker {
         let expected_exitcode = self.protocol.exitcode.unwrap_or(0);
         if exitcode != expected_exitcode {
             self.register_step_error(
+                None,
                 &format!("<exitcode {}>", expected_exitcode),
                 &format!("<exitcode {}>", exitcode),
             );

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -64,6 +64,7 @@ impl SyscallMock for Recorder {
             self.command = None;
             self.protocol.steps.push_back(Step {
                 command_matcher: CommandMatcher::ExactMatch(command),
+                marker: None,
                 stdout: vec![],
                 exitcode,
             });

--- a/tests/holes.rs
+++ b/tests/holes.rs
@@ -221,7 +221,14 @@ mod errors_in_protocols {
         )?;
         assert_eq!(
             context.get_captured_stdout(),
-            "error:\n  expected: ls -la\n  received: ls\n"
+            trim_margin(
+                r"
+                    |error:
+                    |  in step on line 3,
+                    |  expected: ls -la
+                    |  received: ls
+                "
+            )?
         );
         Ok(())
     }
@@ -256,7 +263,14 @@ mod errors_in_protocols {
         )?;
         assert_eq!(
             context.get_captured_stdout(),
-            "error:\n  expected: ls -foo\n  received: ls\n"
+            trim_margin(
+                r"
+                    |error:
+                    |  in step on line 4,
+                    |  expected: ls -foo
+                    |  received: ls
+                "
+            )?
         );
         Ok(())
     }

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -59,6 +59,7 @@ fn shortens_received_executable_to_file_name_when_reporting_step_error() -> R<()
         Err(&trim_margin(
             "
                 |error:
+                |  in step on line 2,
                 |  expected: cp
                 |  received: mv
             ",

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -139,7 +139,8 @@ mod yaml_parse_errors {
             result,
             format!(
                 "error in {}.protocols.yaml: \
-                 expected: array, got: Integer(42)",
+                 expected: array, \
+                 got: Node(Integer(42), Some(Marker {{ index: 10, line: 1, col: 10 }}))",
                 path_to_string(&script.path())?
             )
         );
@@ -201,6 +202,7 @@ fn failing() -> R<()> {
         Err(&trim_margin(
             "
                 |error:
+                |  in step on line 2,
                 |  expected: cp
                 |  received: mv
             ",
@@ -225,6 +227,7 @@ fn failing_later() -> R<()> {
         Err(&trim_margin(
             "
                 |error:
+                |  in step on line 3,
                 |  expected: cp
                 |  received: mv
             ",
@@ -387,6 +390,7 @@ mod arguments {
             Err(&trim_margin(
                 "
                     |error:
+                    |  in step on line 2,
                     |  expected: cp foo
                     |  received: cp bar
                 ",
@@ -425,6 +429,7 @@ mod arguments {
             Err(&trim_margin(
                 r#"
                     |error:
+                    |  in step on line 2,
                     |  expected: cp "foo bar"
                     |  received: cp foo bar
                 "#,
@@ -450,6 +455,7 @@ fn reports_the_first_error() -> R<()> {
         Err(&trim_margin(
             "
                 |error:
+                |  in step on line 2,
                 |  expected: cp first
                 |  received: mv first
             ",
@@ -476,6 +482,7 @@ mod mismatch_in_number_of_commands {
             Err(&trim_margin(
                 "
                     |error:
+                    |  in step on line 3,
                     |  expected: cp
                     |  received: <script terminated>
                 ",
@@ -625,9 +632,11 @@ mod multiple_protocols {
             Err(&trim_margin(
                 "
                     |error in protocol 1:
+                    |  in step on line 2,
                     |  expected: cp
                     |  received: mv
                     |error in protocol 2:
+                    |  in step on line 4,
                     |  expected: cp
                     |  received: mv
                 ",
@@ -654,6 +663,7 @@ mod multiple_protocols {
                     |protocol 1:
                     |  Tests passed.
                     |error in protocol 2:
+                    |  in step on line 4,
                     |  expected: cp
                     |  received: mv
                 ",
@@ -961,6 +971,7 @@ mod unmocked_commands {
             Err(&trim_margin(
                 "
                     |error:
+                    |  in step on line 3,
                     |  expected: dirname dir/file
                     |  received: ls dir
                 ",


### PR DESCRIPTION
This change depends on a fork of yaml-rust,
https://github.com/hallettj/yaml-rust/tree/load_from_str_with_markers

@hallettj: Here's the PR with the cherry-picked commit.