### PR TITLE
don't create an empty directory 'foo' during tests

### DIFF
--- a/tests/recording.rs
+++ b/tests/recording.rs
@@ -110,13 +110,13 @@ fn records_command_arguments() -> R<()> {
     test_recording(
         "
             |#!/usr/bin/env bash
-            |mkdir -p foo
+            |date --version > /dev/null
         ",
-        "
+        r#"
             |tests:
             |  - steps:
-            |      - mkdir -p foo
-        ",
+            |      - "date --version"
+        "#,
     )
 }
 


### PR DESCRIPTION
This went undetected for so long, because `git status` doesn't show empty directories as untracked.