### PR TITLE
allow to specify expected stdout in test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,10 @@ bincode = "*"
 quale = "*"
 serde_derive = "*"
 serde = "*"
+trim-margin = "*"
 memoffset = "*"
 clap = "*"
 regex = "*"
-
-[build-dependencies]
-trim-margin = "*"
 
 [dev-dependencies]
 test-utils = { path = "test-utils" }

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ tests:
       # List of files and folders that are going to be mocked to exist.
       # Note that directories must include a trailing '/'.
       # Example: ["/www/logs"], default: []
+    stdout?: string
+      # Output that the script is expected to write to stdout.
+      # Example: "script output\n", default: stdout output is not checked.
     stderr?: string
       # Output that the script is expected to write to stderr.
       # Example: "error message\n", default: stderr output is not checked.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use crate::recorder::{hole_recorder::run_against_tests, Recorder};
 use crate::test_checker::executable_mock;
 use crate::test_spec::yaml::write_yaml;
 use crate::test_spec::Tests;
-use crate::tracer::stdio_redirecting::CaptureStderr;
+use crate::tracer::stdio_redirecting::Capture;
 use crate::tracer::Tracer;
 use std::collections::HashMap;
 use std::path::Path;
@@ -144,7 +144,10 @@ fn print_recorded_test(context: &Context, program: &Path) -> R<ExitCode> {
         program,
         vec![],
         HashMap::new(),
-        CaptureStderr::NoCapture,
+        Capture {
+            stdout: false,
+            stderr: false,
+        },
         Recorder::empty(),
     )?;
     write_yaml(&mut *context.stdout(), &Tests::new(vec![test]).serialize()?)?;

--- a/src/recorder/result.rs
+++ b/src/recorder/result.rs
@@ -5,7 +5,7 @@ use crate::test_checker::{
     TestChecker,
 };
 use crate::test_spec::{yaml::write_yaml, Test, Tests};
-use crate::tracer::stdio_redirecting::CaptureStderr;
+use crate::tracer::stdio_redirecting::Capture;
 use crate::tracer::Tracer;
 use crate::{ExitCode, R};
 use std::fs::OpenOptions;
@@ -128,10 +128,9 @@ fn run_against_test(
                 program,
                 test.arguments.clone(),
                 test.env.clone(),
-                if test.stderr.is_some() {
-                    CaptureStderr::Capture
-                } else {
-                    CaptureStderr::NoCapture
+                Capture {
+                    stdout: test.stdout.is_some(),
+                    stderr: test.stderr.is_some(),
                 },
                 $syscall_mock,
             )

--- a/src/test_checker/checker_result.rs
+++ b/src/test_checker/checker_result.rs
@@ -1,4 +1,5 @@
 use crate::ExitCode;
+use trim_margin::MarginTrimmable;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum CheckerResult {
@@ -30,10 +31,18 @@ impl CheckerResult {
     }
 
     pub fn register_step_error(&mut self, expected: &str, received: &str) {
-        self.register_error(format!(
-            "  expected: {}\n  received: {}\n",
-            expected, received
-        ));
+        self.register_error(
+            format!(
+                r"
+                  |  expected: {}
+                  |  received: {}
+                  |
+                ",
+                expected, received
+            )
+            .trim_margin()
+            .unwrap(),
+        );
     }
 
     pub fn register_error(&mut self, message: String) {

--- a/src/test_checker/mod.rs
+++ b/src/test_checker/mod.rs
@@ -4,7 +4,7 @@ pub mod executable_mock;
 use crate::context::Context;
 use crate::test_spec;
 use crate::test_spec::Test;
-use crate::tracer::stdio_redirecting::Redirector;
+use crate::tracer::stdio_redirecting::{Redirect, Redirector};
 use crate::tracer::{tracee_memory, SyscallMock};
 use crate::utils::short_temp_files::ShortTempFile;
 use crate::R;
@@ -69,6 +69,28 @@ impl TestChecker {
         let path = temp_executable.path();
         self.temporary_executables.push(temp_executable);
         Ok(path)
+    }
+
+    fn check_expected_output_stream(&mut self, redirect: &Redirect, expected: Vec<u8>) -> R<()> {
+        match redirect.captured()? {
+            None => panic!(
+                "scriptkeeper bug: {} expected, but not captured",
+                redirect.stream_type
+            ),
+            Some(captured) => {
+                if captured != expected {
+                    self.result.register_error(format!(
+                        "  expected output to {}: {:?}\
+                         \n  received output to {}: {:?}\n",
+                        redirect.stream_type,
+                        String::from_utf8_lossy(&expected).as_ref(),
+                        redirect.stream_type,
+                        String::from_utf8_lossy(&captured).as_ref(),
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -148,20 +170,11 @@ impl SyscallMock for TestChecker {
                 &format!("<exitcode {}>", exitcode),
             );
         }
+        if let Some(expected_stdout) = &self.test.stdout {
+            self.check_expected_output_stream(&redirector.stdout, expected_stdout.clone())?;
+        }
         if let Some(expected_stderr) = &self.test.stderr {
-            match redirector.stderr.captured()? {
-                None => panic!("scriptkeeper bug: stderr expected, but not captured"),
-                Some(captured_stderr) => {
-                    if &captured_stderr != expected_stderr {
-                        self.result.register_error(format!(
-                            "  expected output to stderr: {:?}\
-                             \n  received output to stderr: {:?}\n",
-                            String::from_utf8_lossy(&expected_stderr).as_ref(),
-                            String::from_utf8_lossy(&captured_stderr).as_ref(),
-                        ));
-                    }
-                }
-            }
+            self.check_expected_output_stream(&redirector.stderr, expected_stderr.clone())?;
         }
         Ok(self.result)
     }

--- a/src/test_checker/mod.rs
+++ b/src/test_checker/mod.rs
@@ -15,6 +15,7 @@ use nix::unistd::Pid;
 use std::ffi::OsString;
 use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
+use trim_margin::MarginTrimmable;
 
 #[derive(Debug)]
 pub struct TestChecker {
@@ -79,14 +80,21 @@ impl TestChecker {
             ),
             Some(captured) => {
                 if captured != expected {
-                    self.result.register_error(format!(
-                        "  expected output to {}: {:?}\
-                         \n  received output to {}: {:?}\n",
-                        redirect.stream_type,
-                        String::from_utf8_lossy(&expected).as_ref(),
-                        redirect.stream_type,
-                        String::from_utf8_lossy(&captured).as_ref(),
-                    ));
+                    self.result.register_error(
+                        format!(
+                            r"
+                                |  expected output to {}: {:?}
+                                |  received output to {}: {:?}
+                                |
+                            ",
+                            redirect.stream_type,
+                            String::from_utf8_lossy(&expected).as_ref(),
+                            redirect.stream_type,
+                            String::from_utf8_lossy(&captured).as_ref(),
+                        )
+                        .trim_margin()
+                        .unwrap(),
+                    );
                 }
             }
         }

--- a/src/test_spec/mod.rs
+++ b/src/test_spec/mod.rs
@@ -196,7 +196,7 @@ pub struct Test {
     pub arguments: Vec<String>,
     pub env: HashMap<String, String>,
     pub cwd: Option<PathBuf>,
-    stdout: Option<Vec<u8>>,
+    pub stdout: Option<Vec<u8>>,
     pub stderr: Option<Vec<u8>>,
     pub exitcode: Option<i32>,
     pub mocked_files: Vec<PathBuf>,

--- a/src/test_spec/yaml.rs
+++ b/src/test_spec/yaml.rs
@@ -6,6 +6,8 @@ use std::io::Cursor;
 use yaml_rust::{yaml::Hash, Yaml, YamlEmitter};
 
 pub trait YamlExt {
+    fn expect_bytes(&self) -> R<Vec<u8>>;
+
     fn expect_str(&self) -> R<&str>;
 
     fn expect_array(&self) -> R<&Vec<Yaml>>;
@@ -16,6 +18,11 @@ pub trait YamlExt {
 }
 
 impl YamlExt for Yaml {
+    fn expect_bytes(&self) -> R<Vec<u8>> {
+        let str = self.expect_str()?;
+        Ok(str.as_bytes().to_vec())
+    }
+
     fn expect_str(&self) -> R<&str> {
         Ok(self
             .as_str()

--- a/src/tracer/mod.rs
+++ b/src/tracer/mod.rs
@@ -25,7 +25,7 @@ use std::os::unix::ffi::OsStringExt;
 use std::panic;
 use std::path::{Path, PathBuf};
 use std::str;
-use stdio_redirecting::{CaptureStderr, Redirector};
+use stdio_redirecting::{Capture, Redirector};
 use syscall::Syscall;
 use tempdir::TempDir;
 
@@ -147,10 +147,10 @@ impl Tracer {
         program: &Path,
         args: Vec<String>,
         env: HashMap<String, String>,
-        capture_stderr: CaptureStderr,
+        capture: Capture,
         mut syscall_mock: impl SyscallMock<Result = MockResult>,
     ) -> R<MockResult> {
-        let redirector = Redirector::new(context, capture_stderr)?;
+        let redirector = Redirector::new(context, capture)?;
         fork_with_child_errors(
             || {
                 redirector.child_redirect_streams()?;

--- a/src/tracer/stdio_redirecting.rs
+++ b/src/tracer/stdio_redirecting.rs
@@ -2,6 +2,7 @@ use crate::context::Context;
 use crate::R;
 use libc::c_int;
 use nix::unistd::{close, dup2, pipe, read};
+use std::fmt;
 use std::io::{Cursor, Write};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -9,22 +10,27 @@ use std::thread;
 type RawFd = c_int;
 
 pub struct Redirector {
-    stdout: Redirect,
+    pub stdout: Redirect,
     pub stderr: Redirect,
 }
 
-pub enum CaptureStderr {
-    Capture,
-    NoCapture,
+pub struct Capture {
+    pub stdout: bool,
+    pub stderr: bool,
 }
 
 impl Redirector {
-    pub fn new(context: &Context, capture_stderr: CaptureStderr) -> R<Redirector> {
+    pub fn new(context: &Context, capture: Capture) -> R<Redirector> {
         Ok(Redirector {
-            stdout: Redirect::new(context, StreamType::Stdout)?,
-            stderr: match capture_stderr {
-                CaptureStderr::Capture => Redirect::new_capturing(context, StreamType::Stderr)?,
-                CaptureStderr::NoCapture => Redirect::new(context, StreamType::Stderr)?,
+            stdout: if capture.stdout {
+                Redirect::new_capturing(context, StreamType::Stdout)?
+            } else {
+                Redirect::new_non_capturing(context, StreamType::Stdout)?
+            },
+            stderr: if capture.stderr {
+                Redirect::new_capturing(context, StreamType::Stderr)?
+            } else {
+                Redirect::new_non_capturing(context, StreamType::Stderr)?
             },
         })
     }
@@ -47,13 +53,22 @@ impl Redirector {
 }
 
 #[derive(Clone, Copy)]
-enum StreamType {
+pub enum StreamType {
     Stdout,
     Stderr,
 }
 
+impl fmt::Display for StreamType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            StreamType::Stdout => write!(f, "stdout"),
+            StreamType::Stderr => write!(f, "stderr"),
+        }
+    }
+}
+
 pub struct Redirect {
-    stream_type: StreamType,
+    pub stream_type: StreamType,
     context: Context,
     read_end: RawFd,
     write_end: RawFd,
@@ -61,19 +76,19 @@ pub struct Redirect {
 }
 
 impl Redirect {
-    fn new(context: &Context, stream_type: StreamType) -> R<Redirect> {
-        Redirect::new_internal(context, stream_type, None)
-    }
-
     fn new_capturing(context: &Context, stream_type: StreamType) -> R<Redirect> {
-        Redirect::new_internal(
+        Redirect::new(
             context,
             stream_type,
             Some(Arc::new(Mutex::new(Cursor::new(vec![])))),
         )
     }
 
-    fn new_internal(
+    fn new_non_capturing(context: &Context, stream_type: StreamType) -> R<Redirect> {
+        Redirect::new(context, stream_type, None)
+    }
+
+    fn new(
         context: &Context,
         stream_type: StreamType,
         captured: Option<Arc<Mutex<Cursor<Vec<u8>>>>>,

--- a/tests/integration/files.rs
+++ b/tests/integration/files.rs
@@ -5,7 +5,7 @@
 #![cfg_attr(feature = "ci", deny(warnings))]
 #![deny(clippy::all)]
 
-use crate::utils::test_run;
+use crate::utils::{test_run, Expect};
 use scriptkeeper::R;
 
 #[test]
@@ -24,7 +24,7 @@ fn allows_to_mock_files_existence() -> R<()> {
             |    mockedFiles:
             |      - /foo
         ",
-        Ok(()),
+        Expect::tests_pass(),
     )?;
     Ok(())
 }
@@ -45,7 +45,7 @@ fn allows_to_mock_directory_existence() -> R<()> {
             |    mockedFiles:
             |      - /foo/
         ",
-        Ok(()),
+        Expect::tests_pass(),
     )?;
     Ok(())
 }
@@ -63,7 +63,7 @@ fn does_not_mock_existence_of_unspecified_files() -> R<()> {
             |tests:
             |  - steps: []
         ",
-        Ok(()),
+        Expect::tests_pass(),
     )?;
     Ok(())
 }

--- a/tests/integration/path.rs
+++ b/tests/integration/path.rs
@@ -4,9 +4,8 @@
 )]
 #![deny(clippy::all)]
 
-use crate::utils::test_run;
+use crate::utils::{test_run, Expect};
 use scriptkeeper::R;
-use test_utils::trim_margin;
 
 #[test]
 fn looks_up_step_executable_in_path() -> R<()> {
@@ -19,7 +18,7 @@ fn looks_up_step_executable_in_path() -> R<()> {
             |steps:
             |  - cp
         ",
-        Ok(()),
+        Expect::tests_pass(),
     )?;
     Ok(())
 }
@@ -37,7 +36,7 @@ fn looks_up_unmocked_command_executable_in_path() -> R<()> {
             |unmockedCommands:
             |  - ls
         ",
-        Ok(()),
+        Expect::tests_pass(),
     )?;
     Ok(())
 }
@@ -53,13 +52,13 @@ fn shortens_received_executable_to_file_name_when_reporting_step_error() -> R<()
             |steps:
             |  - cp
         ",
-        Err(&trim_margin(
+        Expect::error_message(
             "
                 |error:
                 |  expected: cp
                 |  received: mv
             ",
-        )?),
+        )?,
     )?;
     Ok(())
 }
@@ -75,7 +74,7 @@ fn runs_step_executable_that_is_not_in_path() -> R<()> {
             |steps:
             |  - /not/in/path
         ",
-        Ok(()),
+        Expect::tests_pass(),
     )?;
     Ok(())
 }


### PR DESCRIPTION
fixes #101 

This PR also changes the `test_run` family of test helpers to take a value of a new type, `Expect`, which provides more flexibility for specifying expected results.