### PR TITLE
allow to mock stderr output of test step commands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use crate::recorder::{hole_recorder::run_against_tests, Recorder};
 use crate::test_checker::executable_mock;
 use crate::test_spec::yaml::write_yaml;
 use crate::test_spec::Tests;
-use crate::tracer::stdio_redirecting::CaptureStderr;
+use crate::tracer::stdio_redirecting::Capture;
 use crate::tracer::Tracer;
 use std::collections::HashMap;
 use std::path::Path;
@@ -140,7 +140,10 @@ fn print_recorded_test(context: &Context, program: &Path) -> R<ExitCode> {
         program,
         vec![],
         HashMap::new(),
-        CaptureStderr::NoCapture,
+        Capture {
+            stdout: false,
+            stderr: false,
+        },
         Recorder::empty(),
     )?;
     write_yaml(&mut *context.stdout(), &Tests::new(vec![test]).serialize()?)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ mod run_main {
             &context,
             executable_mock::Config {
                 stdout: b"foo".to_vec(),
+                stderr: vec![],
                 exitcode: 0,
             },
         )?;

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -65,6 +65,7 @@ impl SyscallMock for Recorder {
             self.test.steps.push_back(Step {
                 command_matcher: CommandMatcher::ExactMatch(command),
                 stdout: vec![],
+                stderr: vec![],
                 exitcode,
             });
         }

--- a/src/recorder/result.rs
+++ b/src/recorder/result.rs
@@ -5,7 +5,7 @@ use crate::test_checker::{
     TestChecker,
 };
 use crate::test_spec::{yaml::write_yaml, Test, Tests};
-use crate::tracer::stdio_redirecting::CaptureStderr;
+use crate::tracer::stdio_redirecting::Capture;
 use crate::tracer::Tracer;
 use crate::{ExitCode, R};
 use std::fs::OpenOptions;
@@ -128,10 +128,9 @@ fn run_against_test(
                 program,
                 test.arguments.clone(),
                 test.env.clone(),
-                if test.stderr.is_some() {
-                    CaptureStderr::Capture
-                } else {
-                    CaptureStderr::NoCapture
+                Capture {
+                    stdout: test.stdout.is_some(),
+                    stderr: test.stderr.is_some(),
                 },
                 $syscall_mock,
             )

--- a/src/test_checker/mod.rs
+++ b/src/test_checker/mod.rs
@@ -39,6 +39,7 @@ impl TestChecker {
     fn allow_failing_scripts_to_continue() -> executable_mock::Config {
         executable_mock::Config {
             stdout: vec![],
+            stderr: vec![],
             exitcode: 0,
         }
     }
@@ -54,6 +55,7 @@ impl TestChecker {
                 }
                 executable_mock::Config {
                     stdout: next_test_step.stdout,
+                    stderr: next_test_step.stderr,
                     exitcode: next_test_step.exitcode,
                 }
             }

--- a/src/test_spec/mod.rs
+++ b/src/test_spec/mod.rs
@@ -196,7 +196,7 @@ pub struct Test {
     pub arguments: Vec<String>,
     pub env: HashMap<String, String>,
     pub cwd: Option<PathBuf>,
-    stdout: Option<Vec<u8>>,
+    pub stdout: Option<Vec<u8>>,
     pub stderr: Option<Vec<u8>>,
     pub exitcode: Option<i32>,
     pub mocked_files: Vec<PathBuf>,

--- a/src/test_spec/mod.rs
+++ b/src/test_spec/mod.rs
@@ -169,6 +169,15 @@ mod parse_step {
         Ok(())
     }
 
+    #[test]
+    fn allows_to_specify_stderr() -> R<()> {
+        assert_eq!(
+            test_parse_step(r#"{command: "foo", stderr: "bar"}"#)?.stderr,
+            b"bar".to_vec(),
+        );
+        Ok(())
+    }
+
     mod exitcode {
         use super::*;
 

--- a/src/test_spec/yaml.rs
+++ b/src/test_spec/yaml.rs
@@ -6,6 +6,8 @@ use std::io::Cursor;
 use yaml_rust::{yaml::Hash, Yaml, YamlEmitter};
 
 pub trait YamlExt {
+    fn expect_bytes(&self) -> R<Vec<u8>>;
+
     fn expect_str(&self) -> R<&str>;
 
     fn expect_array(&self) -> R<&Vec<Yaml>>;
@@ -16,6 +18,11 @@ pub trait YamlExt {
 }
 
 impl YamlExt for Yaml {
+    fn expect_bytes(&self) -> R<Vec<u8>> {
+        let str = self.expect_str()?;
+        Ok(str.as_bytes().to_vec())
+    }
+
     fn expect_str(&self) -> R<&str> {
         Ok(self
             .as_str()

--- a/src/tracer/mod.rs
+++ b/src/tracer/mod.rs
@@ -25,7 +25,7 @@ use std::os::unix::ffi::OsStringExt;
 use std::panic;
 use std::path::{Path, PathBuf};
 use std::str;
-use stdio_redirecting::{CaptureStderr, Redirector};
+use stdio_redirecting::{Capture, Redirector};
 use syscall::Syscall;
 use tempdir::TempDir;
 
@@ -147,10 +147,10 @@ impl Tracer {
         program: &Path,
         args: Vec<String>,
         env: HashMap<String, String>,
-        capture_stderr: CaptureStderr,
+        capture: Capture,
         mut syscall_mock: impl SyscallMock<Result = MockResult>,
     ) -> R<MockResult> {
-        let redirector = Redirector::new(context, capture_stderr)?;
+        let redirector = Redirector::new(context, capture)?;
         fork_with_child_errors(
             || {
                 redirector.child_redirect_streams()?;

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -9,7 +9,7 @@
 mod utils;
 
 use scriptkeeper::R;
-use utils::test_run;
+use utils::{test_run, Expect};
 
 #[test]
 fn allows_to_mock_files_existence() -> R<()> {
@@ -27,7 +27,7 @@ fn allows_to_mock_files_existence() -> R<()> {
             |    mockedFiles:
             |      - /foo
         ",
-        Ok(()),
+        Expect::ok(),
     )?;
     Ok(())
 }
@@ -48,7 +48,7 @@ fn allows_to_mock_directory_existence() -> R<()> {
             |    mockedFiles:
             |      - /foo/
         ",
-        Ok(()),
+        Expect::ok(),
     )?;
     Ok(())
 }
@@ -66,7 +66,7 @@ fn does_not_mock_existence_of_unspecified_files() -> R<()> {
             |tests:
             |  - steps: []
         ",
-        Ok(()),
+        Expect::ok(),
     )?;
     Ok(())
 }

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -9,7 +9,7 @@ mod utils;
 
 use scriptkeeper::R;
 use test_utils::trim_margin;
-use utils::test_run;
+use utils::{test_run, Expect};
 
 #[test]
 fn looks_up_step_executable_in_path() -> R<()> {
@@ -22,7 +22,7 @@ fn looks_up_step_executable_in_path() -> R<()> {
             |steps:
             |  - cp
         ",
-        Ok(()),
+        Expect::ok(),
     )?;
     Ok(())
 }
@@ -40,7 +40,7 @@ fn looks_up_unmocked_command_executable_in_path() -> R<()> {
             |unmockedCommands:
             |  - ls
         ",
-        Ok(()),
+        Expect::ok(),
     )?;
     Ok(())
 }
@@ -56,7 +56,7 @@ fn shortens_received_executable_to_file_name_when_reporting_step_error() -> R<()
             |steps:
             |  - cp
         ",
-        Err(&trim_margin(
+        Expect::err(&trim_margin(
             "
                 |error:
                 |  expected: cp
@@ -78,7 +78,7 @@ fn runs_step_executable_that_is_not_in_path() -> R<()> {
             |steps:
             |  - /not/in/path
         ",
-        Ok(()),
+        Expect::ok(),
     )?;
     Ok(())
 }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -508,67 +508,6 @@ mod mismatch_in_number_of_commands {
     }
 }
 
-mod stdout {
-    use super::*;
-
-    #[test]
-    fn mock_stdout() -> R<()> {
-        test_run(
-            r"
-                |#!/usr/bin/env bash
-                |output=$(cp)
-                |cp $output
-            ",
-            r"
-                |steps:
-                |  - command: cp
-                |    stdout: test_output
-                |  - cp test_output
-            ",
-            Expect::ok(),
-        )?;
-        Ok(())
-    }
-
-    #[test]
-    fn mock_stdout_with_special_characters() -> R<()> {
-        test_run(
-            r"
-                |#!/usr/bin/env bash
-                |output=$(cp)
-                |cp $output
-            ",
-            r#"
-                |steps:
-                |  - command: cp
-                |    stdout: 'foo"'
-                |  - 'cp foo\"'
-            "#,
-            Expect::ok(),
-        )?;
-        Ok(())
-    }
-
-    #[test]
-    fn mock_stdout_with_newlines() -> R<()> {
-        test_run(
-            r#"
-                |#!/usr/bin/env bash
-                |output=$(cp)
-                |cp "$output"
-            "#,
-            r#"
-                |steps:
-                |  - command: cp
-                |    stdout: "foo\nbar"
-                |  - 'cp foo\nbar'
-            "#,
-            Expect::ok(),
-        )?;
-        Ok(())
-    }
-}
-
 #[test]
 fn pass_arguments_into_tested_script() -> R<()> {
     test_run(

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -14,7 +14,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 use test_utils::{assert_error, trim_margin, TempFile};
-use utils::{prepare_script, test_run, test_run_with_tempfile};
+use utils::{prepare_script, test_run, test_run_with_tempfile, Expect};
 
 #[test]
 fn simple() -> R<()> {
@@ -27,7 +27,7 @@ fn simple() -> R<()> {
             |steps:
             |  - cp
         ",
-        Ok(()),
+        Expect::ok(),
     )?;
     Ok(())
 }
@@ -99,7 +99,7 @@ fn can_specify_interpreter() -> R<()> {
             |    - "true"
             |interpreter: /usr/bin/ruby
         "#,
-        Ok(()),
+        Expect::ok(),
     )?;
     Ok(())
 }
@@ -116,7 +116,7 @@ fn allows_to_match_command_with_regex() -> R<()> {
             |  - steps:
             |    - regex: cp \d
         "#,
-        Ok(()),
+        Expect::ok(),
     )?;
     Ok(())
 }
@@ -182,7 +182,7 @@ fn multiple() -> R<()> {
             |  - cp
             |  - ls
         ",
-        Ok(()),
+        Expect::ok(),
     )?;
     Ok(())
 }
@@ -198,7 +198,7 @@ fn failing() -> R<()> {
             |steps:
             |  - cp
         ",
-        Err(&trim_margin(
+        Expect::err(&trim_margin(
             "
                 |error:
                 |  expected: cp
@@ -222,7 +222,7 @@ fn failing_later() -> R<()> {
             |  - ls
             |  - cp
         ",
-        Err(&trim_margin(
+        Expect::err(&trim_margin(
             "
                 |error:
                 |  expected: cp
@@ -368,7 +368,7 @@ mod arguments {
                 |steps:
                 |  - cp foo
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -384,7 +384,7 @@ mod arguments {
                 |steps:
                 |  - cp foo
             ",
-            Err(&trim_margin(
+            Expect::err(&trim_margin(
                 "
                     |error:
                     |  expected: cp foo
@@ -406,7 +406,7 @@ mod arguments {
                 |steps:
                 |  - cp "foo bar"
             "#,
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -422,7 +422,7 @@ mod arguments {
                 |steps:
                 |  - cp "foo bar"
             "#,
-            Err(&trim_margin(
+            Expect::err(&trim_margin(
                 r#"
                     |error:
                     |  expected: cp "foo bar"
@@ -447,7 +447,7 @@ fn reports_the_first_error() -> R<()> {
             |  - cp first
             |  - cp second
         ",
-        Err(&trim_margin(
+        Expect::err(&trim_margin(
             "
                 |error:
                 |  expected: cp first
@@ -473,7 +473,7 @@ mod mismatch_in_number_of_commands {
                 |  - ls
                 |  - cp
             ",
-            Err(&trim_margin(
+            Expect::err(&trim_margin(
                 "
                     |error:
                     |  expected: cp
@@ -496,7 +496,7 @@ mod mismatch_in_number_of_commands {
                 |steps:
                 |  - ls
             ",
-            Err(&trim_margin(
+            Expect::err(&trim_margin(
                 "
                     |error:
                     |  expected: <script termination>
@@ -525,7 +525,7 @@ mod stdout {
                 |    stdout: test_output
                 |  - cp test_output
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -544,7 +544,7 @@ mod stdout {
                 |    stdout: 'foo"'
                 |  - 'cp foo\"'
             "#,
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -563,7 +563,7 @@ mod stdout {
                 |    stdout: "foo\nbar"
                 |  - 'cp foo\nbar'
             "#,
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -581,7 +581,7 @@ fn pass_arguments_into_tested_script() -> R<()> {
             |steps:
             |  - cp foo
         ",
-        Ok(()),
+        Expect::ok(),
     )?;
     Ok(())
 }
@@ -604,7 +604,7 @@ mod multiple_tests {
                 |  steps:
                 |    - cp bar
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -622,7 +622,7 @@ mod multiple_tests {
                 |- steps:
                 |    - cp
             ",
-            Err(&trim_margin(
+            Expect::err(&trim_margin(
                 "
                     |error in test 1:
                     |  expected: cp
@@ -649,7 +649,7 @@ mod multiple_tests {
                 |- steps:
                 |    - cp
             ",
-            Err(&trim_margin(
+            Expect::err(&trim_margin(
                 "
                     |test 1:
                     |  Tests passed.
@@ -679,7 +679,7 @@ mod environment {
                 |steps:
                 |  - cp test-env-var
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -696,7 +696,7 @@ mod environment {
                 |steps:
                 |  - cp
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -713,7 +713,7 @@ fn detects_running_commands_from_ruby_scripts() -> R<()> {
             |steps:
             |  - ls
         ",
-        Ok(()),
+        Expect::ok(),
     )?;
     Ok(())
 }
@@ -736,7 +736,7 @@ mod mocked_exitcodes {
                 |    exitcode: 1
                 |  - ls
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -756,7 +756,7 @@ mod mocked_exitcodes {
                 |    exitcode: 0
                 |  - ls
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -775,7 +775,7 @@ mod mocked_exitcodes {
                 |  - grep foo
                 |  - ls
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -794,7 +794,7 @@ mod mocked_exitcodes {
                 |    exitcode: 42
                 |  - ls 42
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -815,7 +815,7 @@ mod working_directory {
                 |steps:
                 |  - ls /foo/file
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -832,7 +832,7 @@ mod working_directory {
                 |steps:
                 |  - ls /foo/bar/baz/foo/bar/baz/foo/bar/baz/foo/file
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -852,7 +852,7 @@ mod working_directory {
                 ",
                 path_to_string(&cwd)?
             ),
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -871,7 +871,7 @@ mod expected_exitcode {
             r"
                 |steps: []
             ",
-            Err(&trim_margin(
+            Expect::err(&trim_margin(
                 "
                     |error:
                     |  expected: <exitcode 0>
@@ -893,7 +893,7 @@ mod expected_exitcode {
                 |steps: []
                 |exitcode: 42
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -909,7 +909,7 @@ mod expected_exitcode {
                 |steps: []
                 |exitcode: 42
             ",
-            Err(&trim_margin(
+            Expect::err(&trim_margin(
                 "
                 |error:
                 |  expected: <exitcode 42>
@@ -938,7 +938,7 @@ mod unmocked_commands {
                 |unmockedCommands:
                 |  - dirname
             ",
-            Ok(()),
+            Expect::ok(),
         )?;
         Ok(())
     }
@@ -958,7 +958,7 @@ mod unmocked_commands {
                 |unmockedCommands:
                 |  - dirname
             ",
-            Err(&trim_margin(
+            Expect::err(&trim_margin(
                 "
                     |error:
                     |  expected: dirname dir/file

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -209,6 +209,44 @@ mod mocked_stderr {
         )?;
         Ok(())
     }
+
+    #[test]
+    fn mock_stderr_with_special_characters() -> R<()> {
+        test_run(
+            r"
+                |#!/usr/bin/env bash
+                |output=$(cp 2>&1)
+                |cp $output
+            ",
+            r#"
+                |steps:
+                |  - command: cp
+                |    stderr: 'foo"'
+                |  - 'cp foo\"'
+            "#,
+            Expect::ok(),
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn mock_stderr_with_newlines() -> R<()> {
+        test_run(
+            r#"
+                |#!/usr/bin/env bash
+                |output=$(cp 2>&1)
+                |cp "$output"
+            "#,
+            r#"
+                |steps:
+                |  - command: cp
+                |    stderr: "foo\nbar"
+                |  - 'cp foo\nbar'
+            "#,
+            Expect::ok(),
+        )?;
+        Ok(())
+    }
 }
 
 mod expected_stderr {

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -44,6 +44,96 @@ fn relays_stderr_from_the_tested_script_to_the_user() -> R<()> {
     Ok(())
 }
 
+mod expected_stdout {
+    use super::*;
+
+    #[test]
+    fn fails_when_not_matching() -> R<()> {
+        test_run(
+            r"
+                |#!/usr/bin/env bash
+                |echo bar
+            ",
+            r#"
+                |tests:
+                |  - steps: []
+                |    stdout: "foo\n"
+            "#,
+            Expect::err(&trim_margin(
+                r#"
+                    |bar
+                    |error:
+                    |  expected output to stdout: "foo\n"
+                    |  received output to stdout: "bar\n"
+                "#,
+            )?),
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_matching() -> R<()> {
+        test_run(
+            r"
+                |#!/usr/bin/env bash
+                |echo foo
+            ",
+            r#"
+                |tests:
+                |  - steps: []
+                |    stdout: "foo\n"
+            "#,
+            Expect::ok().stdout("foo\nAll tests passed.\n"),
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn fails_when_expecting_stdout_but_none_printed() -> R<()> {
+        test_run(
+            r"
+                |#!/usr/bin/env bash
+            ",
+            r#"
+                |tests:
+                |  - steps: []
+                |    stdout: "foo\n"
+            "#,
+            Expect::err(&trim_margin(
+                r#"
+                    |error:
+                    |  expected output to stdout: "foo\n"
+                    |  received output to stdout: ""
+                "#,
+            )?),
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn when_not_specified_but_scripts_writes_to_stdout() -> R<()> {
+        let result = test_run_with_tempfile(
+            &Context::new_mock(),
+            &TempFile::write_temp_script(
+                trim_margin(
+                    r"
+                        |#!/usr/bin/env bash
+                        |echo foo
+                    ",
+                )?
+                .as_bytes(),
+            )?,
+            r#"
+                |protocols:
+                |  - protocol: []
+            "#,
+        )?;
+        assert_eq!(result.0, ExitCode(0));
+        assert_eq!(result.1, "foo\nAll tests passed.\n");
+        Ok(())
+    }
+}
+
 mod expected_stderr {
     use super::*;
 

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -188,6 +188,29 @@ mod expected_stdout {
     }
 }
 
+mod mocked_stderr {
+    use super::*;
+
+    #[test]
+    fn mock_stderr() -> R<()> {
+        test_run(
+            r"
+                |#!/usr/bin/env bash
+                |output=$(date 2>&1)
+                |mkdir $output
+            ",
+            r"
+                |steps:
+                |  - command: date
+                |    stderr: '2019-04-08'
+                |  - mkdir 2019-04-08
+            ",
+            Expect::ok(),
+        )?;
+        Ok(())
+    }
+}
+
 mod expected_stderr {
     use super::*;
 

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -112,24 +112,17 @@ mod expected_stdout {
 
     #[test]
     fn when_not_specified_but_scripts_writes_to_stdout() -> R<()> {
-        let result = test_run_with_tempfile(
-            &Context::new_mock(),
-            &TempFile::write_temp_script(
-                trim_margin(
-                    r"
-                        |#!/usr/bin/env bash
-                        |echo foo
-                    ",
-                )?
-                .as_bytes(),
-            )?,
+        test_run(
+            r"
+                |#!/usr/bin/env bash
+                |echo foo
+            ",
             r#"
-                |protocols:
-                |  - protocol: []
+                |tests:
+                |  - steps: []
             "#,
+            Expect::ok().stdout("foo\nAll tests passed.\n"),
         )?;
-        assert_eq!(result.0, ExitCode(0));
-        assert_eq!(result.1, "foo\nAll tests passed.\n");
         Ok(())
     }
 }
@@ -201,5 +194,18 @@ mod expected_stderr {
     }
 
     #[test]
-    fn when_not_specified_but_scripts_writes_to_stderr() {}
+    fn when_not_specified_but_scripts_writes_to_stderr() -> R<()> {
+        test_run(
+            r"
+                |#!/usr/bin/env bash
+                |echo foo 1>&2
+            ",
+            r#"
+                |tests:
+                |  - steps: []
+            "#,
+            Expect::ok().stderr("foo\n"),
+        )?;
+        Ok(())
+    }
 }

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -44,6 +44,67 @@ fn relays_stderr_from_the_tested_script_to_the_user() -> R<()> {
     Ok(())
 }
 
+mod mocked_stdout {
+    use super::*;
+
+    #[test]
+    fn mock_stdout() -> R<()> {
+        test_run(
+            r"
+                |#!/usr/bin/env bash
+                |output=$(cp)
+                |cp $output
+            ",
+            r"
+                |steps:
+                |  - command: cp
+                |    stdout: test_output
+                |  - cp test_output
+            ",
+            Expect::ok(),
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn mock_stdout_with_special_characters() -> R<()> {
+        test_run(
+            r"
+                |#!/usr/bin/env bash
+                |output=$(cp)
+                |cp $output
+            ",
+            r#"
+                |steps:
+                |  - command: cp
+                |    stdout: 'foo"'
+                |  - 'cp foo\"'
+            "#,
+            Expect::ok(),
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn mock_stdout_with_newlines() -> R<()> {
+        test_run(
+            r#"
+                |#!/usr/bin/env bash
+                |output=$(cp)
+                |cp "$output"
+            "#,
+            r#"
+                |steps:
+                |  - command: cp
+                |    stdout: "foo\nbar"
+                |  - 'cp foo\nbar'
+            "#,
+            Expect::ok(),
+        )?;
+        Ok(())
+    }
+}
+
 mod expected_stdout {
     use super::*;
 

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -14,12 +14,47 @@ use std::path::PathBuf;
 use test_utils::{trim_margin, TempFile};
 use yaml_rust::YamlLoader;
 
-fn compare_results(result: (ExitCode, String), expected: Result<(), &str>) {
-    let expected_output = match expected {
-        Err(expected_output) => (ExitCode(1), expected_output.to_string()),
-        Ok(()) => (ExitCode(0), "All tests passed.\n".to_string()),
-    };
-    assert_eq!(result, expected_output);
+#[derive(Debug, PartialEq)]
+pub struct Expect {
+    expected_exit_code: ExitCode,
+    expected_stdout: String,
+    expected_stderr: String,
+}
+
+impl Expect {
+    pub fn ok() -> Self {
+        Expect {
+            expected_exit_code: ExitCode(0),
+            expected_stdout: "All tests passed.\n".to_string(),
+            expected_stderr: "".to_string(),
+        }
+    }
+
+    pub fn err(expected_output: &str) -> Self {
+        Expect {
+            expected_exit_code: ExitCode(1),
+            expected_stdout: expected_output.to_string(),
+            expected_stderr: "".to_string(),
+        }
+    }
+
+    pub fn stdout(self, expected_output: &str) -> Self {
+        Expect {
+            expected_stdout: expected_output.to_string(),
+            ..self
+        }
+    }
+
+    pub fn stderr(self, expected_output: &str) -> Self {
+        Expect {
+            expected_stderr: expected_output.to_string(),
+            ..self
+        }
+    }
+}
+
+fn compare_results(actual: Expect, expected: Expect) {
+    assert_eq!(actual, expected);
 }
 
 pub fn prepare_script(script_code: &str, tests: &str) -> R<(TempFile, PathBuf)> {
@@ -46,15 +81,22 @@ pub fn test_run_with_context(
     context: &Context,
     script_code: &str,
     tests: &str,
-    expected: Result<(), &str>,
+    expected: Expect,
 ) -> R<()> {
     let script = TempFile::write_temp_script(trim_margin(script_code)?.as_bytes())?;
-    let result = test_run_with_tempfile(context, &script, tests)?;
-    compare_results(result, expected);
+    let (exit_code, stdout) = test_run_with_tempfile(context, &script, tests)?;
+    compare_results(
+        Expect {
+            expected_exit_code: exit_code,
+            expected_stdout: stdout,
+            expected_stderr: context.get_captured_stderr(),
+        },
+        expected,
+    );
     Ok(())
 }
 
-pub fn test_run(script_code: &str, tests: &str, expected: Result<(), &str>) -> R<()> {
+pub fn test_run(script_code: &str, tests: &str, expected: Expect) -> R<()> {
     test_run_with_context(&Context::new_mock(), script_code, tests, expected)
 }
 


### PR DESCRIPTION
This change is branched from `sh/expected-output` (pr #192) because I wanted to use the `expect_bytes` method that I added in that branch.