### PR TITLE
add script to build a distributable binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/distribution/scriptkeeper

--- a/Justfile
+++ b/Justfile
@@ -18,6 +18,7 @@ doc:
 scripts:
   cargo run -- build-docker-image.sh
   cargo run -- scriptkeeper-in-docker.sh
+  cargo run -- distribution/build.sh
 
 dev pattern='':
   clear ; printf "\e[3J"
@@ -34,3 +35,9 @@ test_dockerfile:
     -v $(pwd)/tests/examples/bigger/script.test.yaml:/root/script.test.yaml \
     scriptkeeper \
     script
+
+distribution_smoke_test: distribution_build
+  ./distribution/smoke-test.sh
+
+distribution_build:
+  ./distribution/build.sh

--- a/README.md
+++ b/README.md
@@ -262,3 +262,20 @@ within docker, when files change:
 ./build-docker-image.sh
 ./test-watch-in-docker.sh
 ```
+
+### Cutting a new release
+
+To cut a new release:
+
+- Bump the version number in the `Cargo.toml`
+- Run `just ci`
+- `git tag` with the version number (no leading `v`)
+- Run `git push --tags`
+- Create a release on github for the created tag
+- Run `just distribution_build`
+- Upload `distribution/scriptkeeper` as a binary release to github
+
+There's a script `distribution/smoke-test.sh` that allows to smoke-test the
+distribution executable in a bunch of different docker images. This can be used
+to make sure that all dynamically linked dependencies are available on those
+systems.

--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -1,0 +1,18 @@
+FROM centos:6.10
+RUN yum install --assumeyes gcc
+
+# install rust toolchain
+WORKDIR /root
+RUN curl https://sh.rustup.rs -sSf >> rustup.sh
+RUN chmod +x rustup.sh
+RUN ./rustup.sh -y
+ENV PATH=/root/.cargo/bin:$PATH
+
+# build scriptkeeper
+WORKDIR /root/scriptkeeper
+ADD Cargo.* ./
+RUN mkdir src && touch src/lib.rs && cargo install --root /usr/local --path . ; true
+ADD src ./src
+RUN touch src/lib.rs
+RUN cargo install --root /usr/local --path .
+RUN strip /usr/local/bin/scriptkeeper

--- a/distribution/build.sh
+++ b/distribution/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu
+
+image=scriptkeeper-distribution
+container=$image-container
+
+docker build --file distribution/Dockerfile . --tag scriptkeeper-distribution
+
+docker run --name $container $image true
+docker cp $container:/usr/local/bin/scriptkeeper distribution/
+docker rm $container

--- a/distribution/build.sh.test.yaml
+++ b/distribution/build.sh.test.yaml
@@ -1,0 +1,6 @@
+tests:
+  - steps:
+      - docker build --file distribution/Dockerfile . --tag scriptkeeper-distribution
+      - docker run --name scriptkeeper-distribution-container scriptkeeper-distribution true
+      - docker cp scriptkeeper-distribution-container:/usr/local/bin/scriptkeeper distribution/
+      - docker rm scriptkeeper-distribution-container

--- a/distribution/smoke-test.sh
+++ b/distribution/smoke-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eu
+
+scriptkeeper=/root/scriptkeeper/distribution/scriptkeeper
+test_script=/root/scriptkeeper/tests/examples/bigger/script
+
+images=(
+  centos:6.10
+  centos:7.6.1810
+
+  opensuse/leap:15.1
+  opensuse/leap:42.3
+
+  debian:squeeze
+  debian:wheezy
+  debian:jessie
+  debian:stretch
+  debian:buster
+
+  fedora:26
+  fedora:27
+  fedora:28
+  fedora:29
+
+  ubuntu:14.04
+  ubuntu:14.10
+  ubuntu:15.04
+  ubuntu:15.10
+  ubuntu:16.04
+  ubuntu:16.10
+  ubuntu:17.04
+  ubuntu:17.10
+  ubuntu:18.04
+  ubuntu:18.10
+  ubuntu:19.04
+)
+
+for image in ${images[@]} ; do
+  echo testing $image
+  docker run --rm -i -v $(pwd):/root/scriptkeeper \
+    --cap-add=SYS_PTRACE \
+    $image $scriptkeeper $test_script
+done


### PR DESCRIPTION
This PR adds a script that allows to build a binary of scriptkeeper into `distribution/scriptkeeper`. It's built inside docker with an older centOS image, so that it doesn't depend on a newer version of glibc. This will hopefully make it work on more distributions. There's also a test script that makes sure that the dynamic dependencies can be found on a bunch of distributions.

My plan is to merge this and then cut a release (I think version `0.2.0`) and upload that binary manually to the release on github. (We can also automate that process later.)