### PR TITLE
pin down rustc version in both Dockerfiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.34.0-stretch
+      - image: rust:1.34.2-stretch
 
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
           name: test docker scripts
           command: |
             cp /bin/true /usr/bin/docker
-            cargo run -- build-docker-image.sh
             cargo run -- scriptkeeper-in-docker.sh
             cargo run -- distribution/build.sh
       - save_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:1.34.0
+ARG RUSTC_VERSION
+FROM rust:${RUSTC_VERSION}
 
 RUN cargo install cargo-watch
 RUN apt-get update && apt-get install -y ruby

--- a/Justfile
+++ b/Justfile
@@ -16,7 +16,6 @@ doc:
   cargo doc
 
 scripts:
-  cargo run -- build-docker-image.sh
   cargo run -- scriptkeeper-in-docker.sh
   cargo run -- distribution/build.sh
 
@@ -27,8 +26,12 @@ dev pattern='':
 run_bigger:
   cargo run -- tests/examples/bigger/script
 
-test_dockerfile:
-  docker build -t scriptkeeper .
+export RUSTC_VERSION := "1.34.2"
+
+build_docker_image:
+  docker build --build-arg RUSTC_VERSION -t scriptkeeper .
+
+test_dockerfile: build_docker_image
   docker run --rm \
     --cap-add=SYS_PTRACE \
     -v $(pwd)/tests/examples/bigger/script:/root/script \

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ run inside of docker. Luckily, we have set up a one-liner for you. This will run
 within docker, when files change:
 
 ``` bash
-./build-docker-image.sh
+just build_docker_image
 ./test-watch-in-docker.sh
 ```
 

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker build -t scriptkeeper .

--- a/build-docker-image.sh.test.yaml
+++ b/build-docker-image.sh.test.yaml
@@ -1,2 +1,0 @@
-steps:
-  - /usr/bin/docker build -t scriptkeeper .

--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -5,7 +5,8 @@ RUN yum install --assumeyes gcc
 WORKDIR /root
 RUN curl https://sh.rustup.rs -sSf >> rustup.sh
 RUN chmod +x rustup.sh
-RUN ./rustup.sh -y
+ARG RUSTC_VERSION
+RUN ./rustup.sh -y --default-toolchain $RUSTC_VERSION
 ENV PATH=/root/.cargo/bin:$PATH
 
 # build scriptkeeper

--- a/distribution/build.sh
+++ b/distribution/build.sh
@@ -5,7 +5,11 @@ set -eu
 image=scriptkeeper-distribution
 container=$image-container
 
-docker build --file distribution/Dockerfile . --tag scriptkeeper-distribution
+docker build \
+  --build-arg RUSTC_VERSION \
+  --file distribution/Dockerfile \
+  --tag scriptkeeper-distribution \
+  .
 
 docker run --name $container $image true
 docker cp $container:/usr/local/bin/scriptkeeper distribution/

--- a/distribution/build.sh.test.yaml
+++ b/distribution/build.sh.test.yaml
@@ -1,6 +1,6 @@
 tests:
   - steps:
-      - docker build --file distribution/Dockerfile . --tag scriptkeeper-distribution
+      - docker build --build-arg RUSTC_VERSION --file distribution/Dockerfile --tag scriptkeeper-distribution .
       - docker run --name scriptkeeper-distribution-container scriptkeeper-distribution true
       - docker cp scriptkeeper-distribution-container:/usr/local/bin/scriptkeeper distribution/
       - docker rm scriptkeeper-distribution-container


### PR DESCRIPTION
This PR pins down the rustc version (to `1.34.2`) for 

- `distribution/Dockerfile` and
- `./Dockerfile`, which is used for running and developing `scriptkeeper` on mac.

The motivation for this PR was to pin down the compiler version for the distributed executable. But I thought it'd be good to DRY up setting the compiler version between the two Dockerfiles. In it's current form that does mean that you have to build the docker image on macs by saying `just build_docker_image` instead of calling `./build-docker-image.sh`.

@matthandlersux: I think you're the only one running this on mac currently, any opinions on this?