### PR TITLE
run scriptkeeper tests for distribution/build.sh on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
             cp /bin/true /usr/bin/docker
             cargo run -- build-docker-image.sh
             cargo run -- scriptkeeper-in-docker.sh
+            cargo run -- distribution/build.sh
       - save_cache:
           key: v1-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
           paths:


### PR DESCRIPTION
Maybe we should try to use `just` on CI to have only one single source of truth for how to run the tests. Anyways, this PR brings what's in the `Justfile` and `.circleci/config.yml` closer together.