### PR TITLE
add installation notes to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Feel free to open (or vote on)
 You can download `scriptkeeper` binaries on the [release
 page](https://github.com/Originate/scriptkeeper/releases). Download the binary,
 make it executable (`chmod +x scriptkeeper`) and optionally put it somewhere in
-your `$PATH`.
+your `$PATH`. All executables in there are for Linux and `x86_64` cpus.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ try it out, I'd be interested to hear which features you would want the most.
 Feel free to open (or vote on)
 [issues](https://github.com/Originate/scriptkeeper/issues).
 
+## Installation
+
+You can download `scriptkeeper` binaries on the [release
+page](https://github.com/Originate/scriptkeeper/releases). Download the binary,
+make it executable (`chmod +x scriptkeeper`) and optionally put it somewhere in
+your `$PATH`.
+
 ## Usage
 
 `scriptkeeper` allows you to write tests for scripts (or other executables) --


### PR DESCRIPTION
This is not the most convenient installation procedure, but that's how it is for now. And certainly better than no binaries at all.