### PR TITLE
fix multiple tests example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Multiple tests can be specified using a YAML array:
     - git add .
     - git push
 # when given the 'pull' argument, it just pulls
-- arguments: push
+- arguments: pull
   steps:
     - git pull
 ```
@@ -184,7 +184,7 @@ tests:
       - git add .
       - git push
   # when given the 'pull' argument, it just pulls
-  - arguments: push
+  - arguments: pull
     steps:
       - git pull
 ```


### PR DESCRIPTION
To my understanding, the `arguments` parameter should be `pull` instead of push `push` when we expect the `git pull` to be executed. This will also avoid having different tests with same arguments.